### PR TITLE
kernel: selinux: add security_bounded_transition hook for kernel < 4.14

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -12,6 +12,7 @@ kernelsu-objs += kernel_compat.o
 kernelsu-objs += selinux/selinux.o
 kernelsu-objs += selinux/sepolicy.o
 kernelsu-objs += selinux/rules.o
+kernelsu-objs += selinux/kernel_compat.o
 ccflags-y += -I$(srctree)/security/selinux -I$(srctree)/security/selinux/include
 ccflags-y += -I$(objtree)/security/selinux -include $(srctree)/include/uapi/asm-generic/errno.h
 

--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -37,6 +37,10 @@ extern void ksu_sucompat_exit();
 extern void ksu_ksud_init();
 extern void ksu_ksud_exit();
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+extern void ksu_enable_selinux_compat();
+#endif
+
 int __init kernelsu_init(void)
 {
 #ifdef CONFIG_KSU_DEBUG
@@ -60,6 +64,9 @@ int __init kernelsu_init(void)
 #ifdef CONFIG_KPROBES
 	ksu_sucompat_init();
 	ksu_ksud_init();
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+	ksu_enable_selinux_compat();
+#endif
 #else
 	pr_alert("KPROBES is disabled, KernelSU may not work, please check https://kernelsu.org/guide/how-to-integrate-for-non-gki.html");
 #endif

--- a/kernel/selinux/Makefile
+++ b/kernel/selinux/Makefile
@@ -1,6 +1,7 @@
 obj-y += selinux.o
 obj-y += sepolicy.o
 obj-y += rules.o
+obj-y += kernel_compat.o
 
 ifeq ($(shell grep -q " current_sid(void)" $(srctree)/security/selinux/include/objsec.h; echo $$?),0)
 ccflags-y += -DKSU_COMPAT_HAS_CURRENT_SID

--- a/kernel/selinux/kernel_compat.c
+++ b/kernel/selinux/kernel_compat.c
@@ -1,0 +1,68 @@
+#include "linux/version.h"
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+#include "linux/types.h"
+#ifdef CONFIG_KPROBES
+#include "linux/kprobes.h"
+#endif
+#include "avc_ss.h"
+
+#include "selinux.h"
+#include "../klog.h" // IWYU pragma: keep
+#include "../arch.h"
+int ksu_handle_security_bounded_transition(u32 *old_sid, u32 *new_sid) {
+	u32 init_sid, su_sid;
+	int error;
+
+	if (!ss_initialized)
+		return 0;
+
+	/* domain unchanged */
+	if (*old_sid == *new_sid)
+		return 0;
+
+	const char *init_domain = INIT_DOMAIN;
+	const char *su_domain = KERNEL_SU_DOMAIN;
+
+	error = security_secctx_to_secid(init_domain, strlen(init_domain), &init_sid);
+	if (error) {
+		pr_warn("cannot get sid of init context, err %d\n", error);
+		return 0;
+	}
+
+	error = security_secctx_to_secid(su_domain, strlen(su_domain), &su_sid);
+	if (error) {
+		pr_warn("cannot get sid of su context, err %d\n", error);
+		return 0;
+	}
+
+	if (*old_sid == init_sid && *new_sid == su_sid) {
+		pr_info("init to su transition found\n");
+		*old_sid = *new_sid;  // make the original func return 0
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_KPROBES
+static int handler_pre(struct kprobe *p, struct pt_regs *regs) {
+	u32 *old_sid = (u32 *)&PT_REGS_PARM1(regs);
+	u32 *new_sid = (u32 *)&PT_REGS_PARM2(regs);
+
+	return ksu_handle_security_bounded_transition(old_sid, new_sid);
+}
+
+static struct kprobe kp = {
+	.symbol_name = "security_bounded_transition",
+	.pre_handler = handler_pre,
+};
+
+// selinux_compat: make ksud init trigger work for kernel < 4.14
+void ksu_enable_selinux_compat() {
+	int ret;
+
+	ret = register_kprobe(&kp);
+	pr_info("selinux_compat: kp: %d\n", ret);
+}
+#endif
+#endif

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -6,8 +6,6 @@
 #include "avc.h"
 #endif
 
-#define KERNEL_SU_DOMAIN "u:r:su:s0"
-
 static int transive_to_domain(const char *domain)
 {
 	struct cred *cred;

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -4,6 +4,9 @@
 #include "linux/types.h"
 #include "linux/version.h"
 
+#define KERNEL_SU_DOMAIN	"u:r:su:s0"
+#define INIT_DOMAIN		"u:r:init:s0"
+
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) || defined(KSU_COMPAT_HAS_SELINUX_STATE)
 #define KSU_COMPAT_USE_SELINUX_STATE
 #endif


### PR DESCRIPTION
- https://github.com/torvalds/linux/commit/af63f4193f9fbbbac50fc766417d74735afd87ef

- SELinux domain transitions under NNP/nosuid environment was introduced in 4.14 by the above commit, for older kernels, we need to make sure our domain transitions are allowed when calling ksud at boot from the init

- Adapted from https://github.com/tiann/KernelSU/issues/270#issuecomment-2097706460 https://github.com/ookiineko/KernelSU/commit/0950fbba5e79820da539054f6eb6d1d48ec96ff4

Fixes #2 